### PR TITLE
Fix some links and a typo

### DIFF
--- a/projects/turtle/turtle-project.html
+++ b/projects/turtle/turtle-project.html
@@ -112,7 +112,7 @@
 <h3 id="fill-color-5-points-total">4. Fill color (5 points total):</h3>
 <p>Fill at least one shape in your scene with a color other than white.</p>
 <h3 id="marker-color-5-points-total">5. Marker color (5 points total):</h3>
-<p>Change the marker’s tracing color for at least one shape in your scene to something other than black. This is demonstrated in the <a href="/projects/turtle/turtle_tutorial.html">Turtle Tutorial</a>.</p>
+<p>Change the marker’s tracing color for at least one shape in your scene to something other than black. This is demonstrated in the <a href="/projects/turtle/turtle-tutorial.html">Turtle Tutorial</a>.</p>
 <h3 id="types-linting-documentation-10-points-total">6. Types, Linting, Documentation (10 points total):</h3>
 <p>Static Types - Be sure to specify each function’s <em>parameter’s types</em> and <em>return type</em>.</p>
 <p>Linting: Good, Pythonic style - refer to the <a href="/resources/style-guide.html">Style Guide</a> for help.</p>
@@ -121,13 +121,11 @@
 <h3 id="above-and-beyond-breaks-up-complex-functions-5-points-total">7. Above and beyond – breaks up complex functions (5 points total):</h3>
 <p>Avoid any single function from becoming <em>too</em> complex. When programming in general, if you find yourself writing a very complex function, it’s likely you should break it down further into simpler functions. To earn credit for this, break your most complex component procedure besides <code>main</code> down further into simpler, but still meaningfully named procedures. To earn credit for this, your component procedure should <em>call</em> these simpler procedures.</p>
 <h3 id="above-and-beyond-try-something-fun-5-points-total">8. Above and beyond – try something fun! (5 points total):</h3>
-<ol start="11" type="1">
-<li>Impress us by trying out something you find interesting! Describe what you are attempting here in the file’s <code>docstring</code> so we know what to look for. Remember, a <code>docstring</code> can span more than one line, it just ends with the <code>"""</code>. Some ideas you could try for here:</li>
-</ol>
+Impress us by trying out something you find interesting! Describe what you are attempting here in the file’s <code>docstring</code> so we know what to look for. Remember, a <code>docstring</code> can span more than one line, it just ends with the <code>"""</code>. Some ideas you could try for here:
 <ul>
 <li>Read through the <code>Turtle</code> documentation page to find a function to use that we did not make use of in the turtle tutorial and make use of it in your project: <a href="https://docs.python.org/3.11/library/turtle.html#turtle-methods" class="uri">https://docs.python.org/3.11/library/turtle.html#turtle-methods</a></li>
 <li>Use loops and procedures in clever ways to draw an interesting pattern or complex component</li>
-<li>Make clever use of randomness in your scene by using a function imported from the <code>random</code> module: https://docs.python.org/3.8/library/random.html</li>
+<li>Make clever use of randomness in your scene by using a function imported from the <code>random</code> module: <a href="https://docs.python.org/3.8/library/random.html" class="uri">https://docs.python.org/3.8/library/random.html</a></li>
 <li>Go above and beyond with a scene more complex than could be achieved with only four components added to it.</li>
 </ul>
 <p>It is worth noting it is very <em>ok</em>, and perhaps expected, for your scene to look like a drawing you might have been proud of in kindergarten. Such is the nature of doing art on a medium you’re new to. The end visual result is less interesting than the process by which you got there. Your grade will not be impacted by the ultimate beauty of your creation. With that said, drawing 5 lines on the screen with as little effort as possible and calling it “art” may very well be <em>art</em>, but will likely not result in full credit. You should be able to look at your program and appreciate that you put significant effort into it.</p>
@@ -194,8 +192,8 @@ def main() -> None:
 <li>Be sure you declare every parameter’s type</li>
 <li>Be sure you declare every return type (since most of this project is <em>procedural</em>, it’s likely they’re <code>None</code>)</li>
 </ol>
-<p>Read the <a href="/students/resources/style-guide.html">Style, Linting and Autograder</a> guide in anticipation of <em>linting</em> (style checking).</p>
-<p>On your first submission, you are likely to see a number of lint and type checking issues arise. Don’t be dismayed! Remember, each is telling you the line number to find the issue on and describes what the issue is. Many of these rules the linter will teach you through some trial and error and by the end of the course you will be in the practice of writing code in a good, Pythonic style. If you do not understand the suggestions, refer to the <a href="/students/resources/style-guide.html#how-to-read-the-autograder">Style, Linting, and Autograder guide</a>.</p>
+<p>Read the <a href="/resources/style-guide.html">Style, Linting and Autograder</a> guide in anticipation of <em>linting</em> (style checking).</p>
+<p>On your first submission, you are likely to see a number of lint and type checking issues arise. Don’t be dismayed! Remember, each is telling you the line number to find the issue on and describes what the issue is. Many of these rules the linter will teach you through some trial and error and by the end of the course you will be in the practice of writing code in a good, Pythonic style. If you do not understand the suggestions, refer to the <a href="/resources/style-guide.html#how-to-read-the-autograder">Style, Linting, and Autograder guide</a>.</p>
 <p>To build your submission, run <code>python -m tools.submission exercises/turtle_project.py</code> to build your submission zip for upload to Gradescope. Don’t forget to backup your work by creating a commit and pushing it to GitHub. For a reminder of this process, see the previous exercises.</p>
 <h2 id="frequently-asked-questions">Frequently Asked Questions</h2>
 <h3 id="how-can-i-get-my-scene-to-render-faster">How can I get my scene to render faster?</h3>

--- a/projects/turtle/turtle-tutorial.html
+++ b/projects/turtle/turtle-tutorial.html
@@ -175,7 +175,7 @@
 </code> </pre>
 <p>Before moving onto the next section, reposition your triangle so that it looks centered and make sure the size of the triangle is relatively large.</p>
 <h3 id="pen-color">Pen Color</h3>
-<p>There are actually two common ways to change the color of the turtle! To complete this next section, open https://htmlcolorcodes.com/color-picker/ in a new tab.</p>
+<p>There are actually two common ways to change the color of the turtle! To complete this next section, open <a href="https://htmlcolorcodes.com/color-picker" target="_blank" rel="noreferrer">https://htmlcolorcodes.com/color-picker</a> in a new tab.</p>
 <ul>
 <li>To change the color with a string value: &lt;<em>turtlevariable</em>&gt;.color(“&lt;<em>color</em>&gt;”)</li>
 </ul>
@@ -235,7 +235,7 @@
 <ol start="2" type="1">
 <li>Practice some of the tutorial commands by:
 <ul>
-<li>changing bob’s color to black or a darker version of your triabgle color</li>
+<li>changing bob’s color to black or a darker version of your triangle color</li>
 <li>using the goto, penup and pendown commands to position <code>bob</code> in the same spot that <code>leo</code> started.</li>
 <li>set <code>bob</code>’s speed to a higher value</li>
 </ul></li>


### PR DESCRIPTION
I noticed some broken links and some typos in the Turtle projects, so I figured I'd try and fix them. 
This probably isn't the correct way to suggest fixes, and so you're free to close this pull request—but given the repository was public, I thought it'd be fun to try to PR something. Apologies.